### PR TITLE
Chunking up writes to big query

### DIFF
--- a/evaluation/evaluation_pipeline/big_query_helper.py
+++ b/evaluation/evaluation_pipeline/big_query_helper.py
@@ -41,15 +41,13 @@ class BigQueryHelper(object):
     try:
       table = self._client.get_table(table_ref)
       for i in range(0, len(rows), chunk_size):
-        self._insert_rows(table, rows[i:chunk_size])
+        self._insert_rows(table, rows[i:i + chunk_size])
 
     except ValueError as e:
       logging.error('Could not insert into requested table %s. Error: %s',
                     table_name, e)
 
   def _insert_rows(self, table, rows):
-    if len(rows) < 1:
-      return
     errors = self._client.insert_rows(table, rows)
     if errors:
       for e in errors:

--- a/evaluation/evaluation_pipeline/big_query_helper.py
+++ b/evaluation/evaluation_pipeline/big_query_helper.py
@@ -23,11 +23,6 @@ from google.cloud import bigquery
 import csv
 
 
-def chunk_rows(rows, chunk_size=1000):
-  for i in range(0, len(rows), chunk_size):
-    yield rows[i:i + chunk_size]
-
-
 class BigQueryHelper(object):
 
   def __init__(self, dataset, secret_json):
@@ -38,23 +33,25 @@ class BigQueryHelper(object):
     """rows will should be a list of dictionaries (one per row).
 
     During insertion, the dictionary keys will be used to find the
-    corresponding field of the schema.
+    corresponding field of the schema. Insertions will be chunked in sizes of
+    maximum 1000 rows per chunk.
     """
     table_ref = self._dataset.table(table_name)
+    chunk_size = 1000
     try:
       table = self._client.get_table(table_ref)
+      for i in range(0, len(rows), chunk_size):
+        self._insert_rows(table, rows[i:chunk_size])
 
-      for row_chunk in chunk_rows(rows):
-        errors = self._client.insert_rows(table, row_chunk)
-        if errors:
-          for e in errors:
-            logging.error('Failure when inserting rows: %s', str(e))
-        else:
-          logging.info('Successfully inserted %d rows into %s', len(row_chunk),
-                       table_name)
     except ValueError as e:
       logging.error('Could not insert into requested table %s. Error: %s',
                     table_name, e)
+
+    def _insert_rows(self, table, rows):
+      errors = self._client.insert_rows(table, rows)
+      if errors:
+        for e in errors:
+          logging.error('Failure when inserting rows: %s', str(e))
 
 
 def store_in_bigquery(scratch_dir, experiment_id, job_uuid, bag_file,

--- a/evaluation/evaluation_pipeline/big_query_helper.py
+++ b/evaluation/evaluation_pipeline/big_query_helper.py
@@ -48,6 +48,8 @@ class BigQueryHelper(object):
                     table_name, e)
 
   def _insert_rows(self, table, rows):
+    if len(rows) < 1:
+      return
     errors = self._client.insert_rows(table, rows)
     if errors:
       for e in errors:

--- a/evaluation/evaluation_pipeline/big_query_helper.py
+++ b/evaluation/evaluation_pipeline/big_query_helper.py
@@ -47,11 +47,11 @@ class BigQueryHelper(object):
       logging.error('Could not insert into requested table %s. Error: %s',
                     table_name, e)
 
-    def _insert_rows(self, table, rows):
-      errors = self._client.insert_rows(table, rows)
-      if errors:
-        for e in errors:
-          logging.error('Failure when inserting rows: %s', str(e))
+  def _insert_rows(self, table, rows):
+    errors = self._client.insert_rows(table, rows)
+    if errors:
+      for e in errors:
+        logging.error('Failure when inserting rows: %s', str(e))
 
 
 def store_in_bigquery(scratch_dir, experiment_id, job_uuid, bag_file,


### PR DESCRIPTION
BigQuery only allows to write 10k rows at a time. Recommendation is to
choose a much lower chunk size though. Thus we split our writes in
chunks of maxsize 1000 rows at a time.