### PR TITLE
Adding experiment id for nightly

### DIFF
--- a/evaluation/cron/k8s_nightly_cronjob.yaml
+++ b/evaluation/cron/k8s_nightly_cronjob.yaml
@@ -3,7 +3,7 @@ kind: CronJob
 metadata:
   name: nightly-evaluation
 spec:
-  schedule: "00 18 * * *"
+  schedule: "00 19 * * *"
   jobTemplate:
     spec:
       template:

--- a/evaluation/cron/nightly_tasks.sh
+++ b/evaluation/cron/nightly_tasks.sh
@@ -11,6 +11,7 @@ python k8s_job_creator/k8s_job_creator.py \
   --running_in_cluster \
   --dataset_list dataset_lists/nightly_evaluation.csv \
   --docker_image eval_nightly:latest \
-  --tags nightly-`date -I` \
+  --tags nightly \
+  --experiment_id nightly-`date -Iminutes` \
   --service_secret=/var/secrets/evaluation/key.json \
   --old_job_deletion_threshold 7

--- a/evaluation/cron/update_cron_job.sh
+++ b/evaluation/cron/update_cron_job.sh
@@ -2,9 +2,7 @@
 set -o errexit
 set -o verbose
 
-docker build -t eu.gcr.io/robco-klose/nightly_cron -f nightly_cron.Dockerfile ..
-docker push eu.gcr.io/robco-klose/nightly_cron
+sh update_nightly_docker.sh
 
-# currently we schedule jobs "nightly" at 20:00 UTC.
 kubectl delete cronjobs nightly-evaluation
 kubectl create -f k8s_nightly_cronjob.yaml

--- a/evaluation/cron/update_nightly_docker.sh
+++ b/evaluation/cron/update_nightly_docker.sh
@@ -1,0 +1,6 @@
+#!/bin/bash
+set -o errexit
+set -o verbose
+
+docker build -t eu.gcr.io/robco-klose/nightly_cron -f nightly_cron.Dockerfile ..
+docker push eu.gcr.io/robco-klose/nightly_cron


### PR DESCRIPTION
Adds experiment id for nightly runs, such that they are grouped in a
single folder on cloud storage. Also updates the nightly cron job
creation to be scheduled at 9pm Berlin time and separates updating the
docker into a separate bash script.